### PR TITLE
fix: Implemented len assertion to avoid panic

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -29,6 +29,11 @@ func SecureCookie(req *http.Request, name string, cookieSecret string) (string, 
 
 		parts := strings.SplitN(cookie.Value, "|", 3)
 
+		// fix potential out of range error
+		if len(parts) != 3 {
+			return "", false
+		}
+
 		val := parts[0]
 		timestamp := parts[1]
 		sig := parts[2]

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -1,0 +1,18 @@
+package permissions
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Secure cookie expects the value to be pipe deliminated
+func TestSecureCookieFormat(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("Cookie", "user=malformeduservalue")
+	_, ok := SecureCookie(req, "user", "foobar")
+
+	if ok {
+		t.Fatalf("TestSecureCookieFormat expected false instead %v", ok)
+	}
+
+}


### PR DESCRIPTION
Howdy Alexander,

I found this bug last night while working on that other issue. In rare cases, because a len() assertion isn't performed, a malformed cookie could cause the application to panic. Fix and test are attached.

Thanks,
Jared