### PR TITLE
chore: Simplify GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,18 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
-        redis-version: [6.x, 7.x]
+        db-version: [6.x, 7.x]
+        distribution: [redis, valkey]
     runs-on: ubuntu-latest
     steps:
-    - name: Start Redis
+    - name: Start database
       uses: shogo82148/actions-setup-redis@v1
       with:
-        redis-version: ${{ matrix.redis-version }}
+        db-version: ${{ matrix.db-version }}
+        distribution: ${{ matrix.distribution }}
         auto-start: "true"
 
-    - name: Wait for Redis to Start
+    - name: Wait for database to Start
       run: sleep 10
 
     - name: Fetch Repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,50 +1,33 @@
-on: [push, pull_request]
 name: Build
+
+on: [push, pull_request]
+
 env:
   GO111MODULE: on
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Start Redis
-      uses: supercharge/redis-github-action@1.4.0
-      with:
-        redis-version: 6
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Test
-      run: cd v2 && go test
-
-  test-cache:
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
+        redis-version: [6, 7]
     runs-on: ubuntu-latest
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.4.0
+      uses: supercharge/redis-github-action@1.8.0
       with:
-        redis-version: 6
+        redis-version: ${{ matrix.redis-version }}
+
+    - name: Wait for Redis to Start
+      run: sleep 15
+
+    - name: Fetch Repository
+      uses: actions/checkout@v4
+
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/go/pkg/mod              # Module download cache
-          ~/.cache/go-build         # Build cache (Linux)
-          ~/Library/Caches/go-build # Build cache (Mac)
-          '%LocalAppData%\go-build' # Build cache (Windows)
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version: ${{ matrix.go-version }}
+
     - name: Test
-      run: cd v2 && go test
+      working-directory: ./v2
+      run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -shuffle=on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
-        db-version: [6.x, 7.x]
+        redbdis-version: [6.x, 7.x]
         distribution: [redis, valkey]
     runs-on: ubuntu-latest
     steps:
     - name: Start database
       uses: shogo82148/actions-setup-redis@v1
       with:
-        db-version: ${{ matrix.db-version }}
+        redis-version: ${{ matrix.db-version }}
         distribution: ${{ matrix.distribution }}
         auto-start: "true"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         redis-version: [6, 7]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
         db-version: [6.x, 7.x]
-        distribution: [redis, valkey]
+        distribution: [redis]
     runs-on: ubuntu-latest
     steps:
     - name: Start Database

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,17 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
-        redis-version: [6, 7]
+        redis-version: [6.x, 7.x]
     runs-on: ubuntu-latest
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.8.0
+      uses: shogo82148/actions-setup-redis@v1
       with:
         redis-version: ${{ matrix.redis-version }}
+        auto-start: "true"
 
     - name: Wait for Redis to Start
-      run: sleep 15
+      run: sleep 10
 
     - name: Fetch Repository
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
+        go-version-file: ./v2/go.mod
+        cache-dependency-path: ./v2/go.sum
 
     - name: Test
       working-directory: ./v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,18 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
-        redis-version: [6.x, 7.x]
+        db-version: [6.x, 7.x]
         distribution: [redis, valkey]
     runs-on: ubuntu-latest
     steps:
-    - name: Start database
+    - name: Start Database
       uses: shogo82148/actions-setup-redis@v1
       with:
         redis-version: ${{ matrix.db-version }}
         distribution: ${{ matrix.distribution }}
         auto-start: "true"
 
-    - name: Wait for database to Start
+    - name: Wait for Database to Start
       run: sleep 10
 
     - name: Fetch Repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
 
 env:
   GO111MODULE: on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
-        redbdis-version: [6.x, 7.x]
+        redis-version: [6.x, 7.x]
         distribution: [redis, valkey]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Remove EOL versions of Go (Anything below 1.20)
- Add support for testing against Redis 6 and 7
- Add recent version of Go to test matrix
- Remove `cache` test, since `setup-go` now does Caching by default
- Update versions of all GitHub Actions
- Use `gotestsum` to run tests
- Add `-race` to detect race conditions
- Add `-shuffle` to run tests in random order.
- Fixed issue causing CI to run twice (push/pr)